### PR TITLE
1.9.2 compatibility

### DIFF
--- a/otask
+++ b/otask
@@ -24,7 +24,6 @@
 
 
 require 'optparse' 
-require 'rdoc/usage'
 require 'ostruct'
 require 'date'
 require 'rubygems'


### PR DESCRIPTION
With this fix, OTask works as expected on ruby 1.9.2 and does not crash anymore when called from 1.9.2.

Best regards,
Mike
