### PR TITLE
Makes apple script execution (in LaunchBar) RVM compatible 

### DIFF
--- a/OTask.applescript
+++ b/OTask.applescript
@@ -8,5 +8,5 @@ on handle_string(actionString)
 end handle_string
 
 on runRubyScript(action)
-	set res to do shell script "$HOME/scripts/otask.rb -g \"" & action & "\""
+	tell application "Terminal" to do script "$HOME/scripts/otask -g \"" & action & "\""
 end runRubyScript


### PR DESCRIPTION
Change the apple scripts so that it is executed in the terminal application, thus loading RVM (if installed) and using the RVM default version of Ruby.
