### PR TITLE
Adding 'Creation Date' to syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ OTask uses a custom syntax to allow entry of the various elements of an action i
  * \#project             (fragment, no spaces)
  * due(due date)        (can be shortened as d(date))
  * start(start date)    (can be shortened as s(date))
+ * create(creation date)    (can be shortened as c(date))
  * (notes)
  * !						(sets task as flagged)
  

--- a/README.txt
+++ b/README.txt
@@ -23,6 +23,7 @@ OTask uses a custom syntax to allow entry of the various elements of an action i
  * #project             (fragment, no spaces)
  * due(due date)        (can be shortened as d(date))
  * start(start date)    (can be shortened as s(date))
+ * create(creation date)(can be shortened as c(date))
  * (notes)
  * !                    (sets task as flagged)
  

--- a/bin/otask
+++ b/bin/otask
@@ -146,6 +146,13 @@ class OTask
       @options.due = duematch.nil? ? false : duematch[1]
       titlestring.sub!(/ d(ue)?\(([^\)]+)\)/,'') unless duematch.nil?
 
+      # creation date
+      creationmatch = titlestring.match(/ c(?:reate)?\(([^\)]+)\)/)
+      @options.creation = creationmatch.nil? ? false : creationmatch[1]
+      titlestring.sub!(/ c(reate)?\(([^\)]+)\)/,'') unless creationmatch.nil?
+
+
+
       @options.notes = ''
       if titlestring =~ /\(([^\)]+)\)/
         @options.notes = $1
@@ -242,6 +249,7 @@ class OTask
       end
       @props['start_date'] = parse_date(@options.start) if @options.start
       @props['due_date'] = parse_date(@options.due) if @options.due
+      @props['creation_date'] = parse_date(@options.creation) if @options.creation
       @props['note'] = @options.notes unless @options.notes == ''
       @props['flagged'] = @options.flagged
       add_task(dd, @props)


### PR DESCRIPTION
Adding this to the syntax in support of some text-based inbox processing needs I have.  I have a running log of inbox items that looks like:
- 2013-09-01-2249 | INBX | [[GUIDE] ADB Workshop and Guide for everyone - xda-developers](http://forum.xda-developers.com/showthread.php?t=879701)  
  > adb backup -f boot.img boot
- 2013-09-02-1623 | INBX | Make a sentiment analysis study that watches language over time and correlates w quant self ideas
- 2013-09-02-1623 | INBX | Lauren likes wide tea cups @done(2013-09-03-1010)
- 2013-09-02-1730 | INBX | Sync yelp and foursquare checkins (!)
- 2013-09-03-0747 | INBX | Shoelaces

I have a different script which runs down this text file and forces me to act on each item (archive, delete, or turn into omnifocus task -- for now, via otask), and I'd like to preserve the creation date because I'd like to, for example, analyze how long it takes me to complete a task from the moment it enters inbox.
