### PR TITLE
Attempt to update documentation to clarify installation and requirements...

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ This is a CLI for OmniFocus. I had an AppleScript/Ruby monstrosity that actually
 
 ### Requirements
 
-You need a few things before this will even think about running for you. RubyGems is a must. I still haven't figured out if that's part of the default OS X install or not, but if you have Developer tools, you've got it. Then you need the 'rb-appscript' gem. You also need the gems 'chronic' and 'amatch'. You can install each by using `gem install gemname`, and you may have to run the command with `sudo`, depending on your system's permissions.
+You need a few things before this will even think about running for you. RubyGems is a must. I still haven't figured out if that's part of the default OS X install or not, but if you have Developer tools, you've got it. Then you need the 'rb-appscript' gem. You also need the gems 'chronic', 'amatch', and 'rake'. You can install each by using `gem install gemname`, and you may have to run the command with `sudo`, depending on your system's permissions.
+
+### Installing
+
+Change the working directory to the folder OTask was extracted to.
+
+Run this command:
+
+rake install_gem
 
 #### Documentation
 

--- a/README.txt
+++ b/README.txt
@@ -84,10 +84,25 @@ You'll find the Action in LaunchBar after it indexes. Type 'ota' (or as much as 
 * rb-appscript
 * chronic
 * amatch
+* rake
+
+== INSTALLING DEPENDENCIES:
+
+To install each of the dependencies manually you can run:
+
+* gem install <requirement>
+
+You may need to run these commands as sudo depending on your system permissions:
+
+* sudo gem install <requirement>
 
 == INSTALL:
 
-* sudo gem install otask
+Change the working directory to the folder OTask was extracted to.
+
+Run:
+
+* rake install_gem
 
 == LICENSE:
 


### PR DESCRIPTION
.... Rake wasn't mentioned in the ReadMe, and I had to find out about it in the posted issues (Hoe-ified the Project). Rake seemed to be required because the original install instructions produced gem not found. Installing dependencies may be easier through rake, but requires that I do more research. I feel this is an improvement for the time being. It also may be worth editing the ReadMe.txt and ReadMe.md to be more consistent stylistically.
