### PR TITLE
Fix ruby 2.2 installation

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 class OTask
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end

--- a/otask.gemspec
+++ b/otask.gemspec
@@ -26,7 +26,7 @@ lib/version.rb
   s.add_development_dependency 'rdoc', '~> 4.1', '>= 4.1.1'
   s.add_development_dependency 'aruba', '~> 0'
   s.add_runtime_dependency('chronic','~> 0.10', '>= 0.10.2')
-  s.add_runtime_dependency 'rb-appscript', '~> 0.6', '>= 0.6.1'
+  s.add_runtime_dependency 'rb-scpt', '~> 1.0.1'
   s.add_runtime_dependency 'amatch', '~> 0.3', '>= 0.3.0'
 
 end


### PR DESCRIPTION
Howdy @ttscoff! :wave:  

I believe this Pull Request will resolve some of the installation troubles folks are mentioning in #12, #14, and possibly #13 by switching from the `rb-appscript` gem to the `rb-scpt` gem.

I've been trying to get to the root of this issue and I think I've figured out what is happening.

- OTask requires the `rb-appscript` as a runtime dependency, but the gem it tries to install from RubyGems is an outdated version based on (I believe) the unmaintained source at https://sourceforge.net/projects/appscript/.
- There is a fork (https://github.com/mattneub/appscript) where more work has occurred, but based on the discussion in https://github.com/mattneub/appscript/issues/12#issuecomment-254410371, it sounds like the maintainers of the fork are having trouble getting in touch with RubyGems about updating the existing gem.
- The `rb-scpt` gem is a Ruby-only fork of the `appscript` repository that contains the [`Config => RbConfig` fix](https://github.com/BrendanThompson/rb-scpt/commit/7e0bdc9b0a68b983c03fbc0d344b341ea596c220) along with other more recent work.
- Based on the conversation in mattneub/appscript#12, an eventual goal may be to point users of the existing `rb-appscript` gem to the `rb-scpt` gem, but the path forward is not completely clear at the moment. 😕 

This Pull Request just updates the dependencies for OTask to use the `rb-scpt` fork instead of the outdated source at https://rubygems.org/gems/rb-appscript.

I also bumped the version number, but I'm not sure if this conforms to the versioning conventions you're using for OTask.  :smiley: