### PR TITLE
Load the correct dependency

### DIFF
--- a/lib/otask.rb
+++ b/lib/otask.rb
@@ -2,7 +2,7 @@ require 'optparse'
 require 'ostruct'
 require 'date'
 require 'rubygems'
-require 'appscript';include Appscript
+require 'rb-scpt';include Appscript
 require 'amatch';include Amatch
 require 'chronic'
 require 'rdoc'
@@ -357,4 +357,3 @@ class OTask
       end if @options.verbose
     end
 end
-

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 class OTask
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end

--- a/otask.gemspec
+++ b/otask.gemspec
@@ -25,8 +25,8 @@ lib/version.rb
   s.add_development_dependency 'rake', '~> 0'
   s.add_development_dependency 'rdoc', '~> 4.1', '>= 4.1.1'
   s.add_development_dependency 'aruba', '~> 0'
-  s.add_runtime_dependency('chronic','~> 0.10', '>= 0.10.2')
-  s.add_runtime_dependency 'rb-scpt', '~> 1.0.1'
+  s.add_runtime_dependency 'chronic','~> 0.10', '>= 0.10.2'
+  s.add_runtime_dependency 'rb-scpt', '~> 1.0', '>=1.0.1'
   s.add_runtime_dependency 'amatch', '~> 0.3', '>= 0.3.0'
 
 end


### PR DESCRIPTION
Howdy again @ttscoff!  :wave:

This is a bit of a follow-up to #15 that fixes an issue I missed when updating this gem to use `rb-scpt`.  The work in #15 updates the gemspec to pull down the `rb-scpt` gem, but `otask.rb` is still trying to load `appscript` instead.  This causes a runtime failure when running OTask on a version of Ruby that doesn't already have an `appscript` gem installed.  🙀 

This PR fixes that by updating the `require` statement to pull in the correct module.  I also cleaned up the formatting in the dependency section of the gemspec and bumped the version number.

Feel free to make changes to anything I've done here!